### PR TITLE
Skip over consul when resetting Consul services

### DIFF
--- a/consulrunner/clusterrunner.go
+++ b/consulrunner/clusterrunner.go
@@ -191,6 +191,9 @@ func (cr *ClusterRunner) Reset() error {
 	services, err := client.Agent().Services()
 	if err == nil {
 		for _, service := range services {
+			if service.Service == "consul" {
+				continue
+			}
 			err1 := client.Agent().ServiceDeregister(service.ID)
 			if err1 != nil {
 				err = err1


### PR DESCRIPTION
Otherwise, `Reset` exits early with the error:

```
Unexpected response code: 500 (Deregistering the consul service is not allowed)
```

Signed-off-by: Swetha Repakula srepaku@us.ibm.com
