### PR TITLE
Remove prefix 'v' when parsing version

### DIFF
--- a/consulrunner/clusterrunner.go
+++ b/consulrunner/clusterrunner.go
@@ -63,10 +63,11 @@ func (cr *ClusterRunner) ConsulVersion() string {
 	session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 	Expect(err).NotTo(HaveOccurred())
 	Eventually(session).Should(gexec.Exit(0))
-	Expect(session.Out).To(gbytes.Say("Consul v"))
+	Expect(session.Out).To(gbytes.Say("Consul "))
 	lines := strings.Split(string(session.Out.Contents()), "\n")
 	versionLine := lines[0]
-	return strings.TrimPrefix(versionLine, "Consul v")
+	//Consul in 'dev' mode does not contain the prefix 'v', only 'Consul 0.7.1-dev'
+	return strings.TrimPrefix(strings.TrimPrefix(versionLine, "Consul "), "v")
 }
 
 func (cr *ClusterRunner) HasPerformanceFlag() bool {


### PR DESCRIPTION
Hi,

When making`consul` from Github repo it does not include the prefix 'v' (i.e: Consul 0.7.1-dev). 

thanks

