### PR TITLE
Add 'Delete' method to delete a key

### DIFF
--- a/kv.go
+++ b/kv.go
@@ -10,6 +10,7 @@ type KV interface {
 	Put(p *api.KVPair, q *api.WriteOptions) (*api.WriteMeta, error)
 	Release(p *api.KVPair, q *api.WriteOptions) (bool, *api.WriteMeta, error)
 	DeleteTree(prefix string, w *api.WriteOptions) (*api.WriteMeta, error)
+	Delete(key string, w *api.WriteOptions) (*api.WriteMeta, error)
 }
 
 type keyValue struct {
@@ -38,4 +39,8 @@ func (kv *keyValue) Release(p *api.KVPair, q *api.WriteOptions) (bool, *api.Writ
 
 func (kv *keyValue) DeleteTree(prefix string, w *api.WriteOptions) (*api.WriteMeta, error) {
 	return kv.keyValue.DeleteTree(prefix, w)
+}
+
+func (kv *keyValue) Delete(key string, w *api.WriteOptions) (*api.WriteMeta, error) {
+	return kv.keyValue.Delete(key, w)
 }


### PR DESCRIPTION
Hi, 

I've added the 'Delete' method to the adapter. Without that it's only possible to 'DeleteTree'.

Thanks